### PR TITLE
xml_variable_struc into xml_variable

### DIFF
--- a/python/modules/task.py
+++ b/python/modules/task.py
@@ -78,13 +78,14 @@ class TASK_FOR(TASK):
 
     def __init__(self, parameters, updates, args):
         TASK.__init__(self, parameters, updates, args)
-        self.variables_sets_list = args['variables_list']
+        self.variables_list = args['variables_list']
         self.task_to_do = args['task_to_do']
         
     def execute_specify(self, env_local, dict_setts):
         env_tmp = env_local.copy()
-        for variables_set in self.variables_sets_list:
-            env_local_for = self.update_env(env_local, env_tmp, variables_set)
+        for variable in self.variables_list:
+            variable_dict = variable.create_dict(env_local)
+            env_local_for = self.update_env(env_local, env_tmp, variable_dict)
             self.task_to_do.execute(env_local_for)
 
 class TASK_QUEUE(TASK):

--- a/python/modules/task.py
+++ b/python/modules/task.py
@@ -83,7 +83,7 @@ class TASK_FOR(TASK):
         
     def execute_specify(self, env_local, dict_setts):
         env_tmp = env_local.copy()
-        for variable in self.variables_list:
+        for variable in self.variables_list.get_raw_value():
             variable_dict = variable.create_dict(env_local)
             env_local_for = self.update_env(env_local, env_tmp, variable_dict)
             self.task_to_do.execute(env_local_for)

--- a/python/modules/variable.py
+++ b/python/modules/variable.py
@@ -102,26 +102,21 @@ class VariableStructure(Variable):
     Parameters with type 'structure' are represented in  xml settings
     as following:
     <parameter key = "<KEY>" type = "structure">
-        <value>
             <parameter key = "<KEY>" value = "<VALUE>" type = "<TYPE>">
             <parameter key = "<KEY>" value = "<VALUE>" type = "<TYPE>">
-        <value/>
     <parameter>
     """
     def __init__(self, key, value, args = {}):
         Variable.__init__(self, key, value, args = {})
 
     def get_variable(self, env):
-        converted_struc = self.get_value(env)
-        var = Variable(self.key, converted_struc)
+        converted_dict = self.get_value(env)
+        var = Variable(self.key, converted_dict)
         return var
         
     def get_value(self, env, args = {}):
-        converted_struc = []
-        for values_set in self.value:
-            tmp_dict = {}
-            for key, variable in values_set.items():
-                tmp_dict[key] = (variable.get_value(env))
-            converted_struc.append(tmp_dict)
-        return converted_struc
+        converted_dict = {}
+        for key, variable in values_set.items():
+            converted_dict[key] = variable.get_value(env)
+        return converted_dict
 

--- a/python/modules/variable.py
+++ b/python/modules/variable.py
@@ -87,3 +87,41 @@ class VariableList(Variable):
         for element in self.value:
             out_list.append(element.get_value(env))
         return out_list
+
+class VariableStructure(Variable):
+    """
+    Variable structure (list of dictionaries)
+    presents as following example:
+        structure = [{<param_key> : Variable,
+                            <param_key2> : Variable2},
+                     {<param_key> : Variable,
+                            <param_key2> : Variable2},
+                            <...> }, 
+        where each list item represents set of parameters from xml.
+
+    Parameters with type 'structure' are represented in  xml settings
+    as following:
+    <parameter key = "<KEY>" type = "structure">
+        <value>
+            <parameter key = "<KEY>" value = "<VALUE>" type = "<TYPE>">
+            <parameter key = "<KEY>" value = "<VALUE>" type = "<TYPE>">
+        <value/>
+    <parameter>
+    """
+    def __init__(self, key, value, args = {}):
+        Variable.__init__(self, key, value, args = {})
+
+    def get_variable(self, env):
+        converted_struc = self.get_value(env)
+        var = Variable(self.key, converted_struc)
+        return var
+        
+    def get_value(self, env, args = {}):
+        converted_struc = []
+        for values_set in self.value:
+            tmp_dict = {}
+            for key, variable in values_set.items():
+                tmp_dict[key] = (variable.get_value(env))
+            converted_struc.append(tmp_dict)
+        return converted_struc
+

--- a/python/modules/variable.py
+++ b/python/modules/variable.py
@@ -24,6 +24,9 @@ class Variable():
     def get_args(self):
         return self.args
 
+    def create_dict(self, env):
+        return {self.key : self.get_variable(env)}
+
 class VariableReference(Variable):
     def __init__(self, key, value, args = {}):
         Variable.__init__(self, key, value, args = {})
@@ -120,3 +123,5 @@ class VariableStructure(Variable):
             converted_dict[key] = variable.get_value(env)
         return converted_dict
 
+    def create_dict(self, env):
+        return self

--- a/python/modules/variable.py
+++ b/python/modules/variable.py
@@ -90,6 +90,9 @@ class VariableList(Variable):
         for element in self.value:
             out_list.append(element.get_value(env))
         return out_list
+    
+    get get_raw_value(self):
+        return self.value
 
 class VariableStructure(Variable):
     """

--- a/python/modules/xml_parser.py
+++ b/python/modules/xml_parser.py
@@ -20,20 +20,17 @@ def _add_variable_parted(settings, parted_params):
         settings[key] = variable
 
 def _parse_variable_structure(key, param, args):
-    dict_list = []
-    for values_set in param:
-        struc_dict = {}
-        for j, subparam in enumerate(values_set):
-            var, subkey = _create_variable(subparam)
-            stuc_dict[subkey] = var
-        dict_list.append(struc_dict)
-    variable = VAR.VariableStructure(key, dict_list)
+    struc_dict = {}
+    for j, subparam in enumerate(param):
+        var, subkey = _create_variable(subparam)
+        stuc_dict[subkey] = var
+    variable = VAR.VariableStructure(key, struc_dict)
     return variable
 
 def _parse_variable_list(key, param):
     values_list = []
-    for i, p_value in enumerate(param):
-        var = _create_variable(p_value, i)[0]
+    for i, subparam in enumerate(param):
+        var = _create_variable(subparam, i)[0]
         values_list.append(var)
     variable = VAR.VariableList(key, values_list)
     return variable

--- a/python/modules/xml_parser.py
+++ b/python/modules/xml_parser.py
@@ -19,6 +19,17 @@ def _add_variable_parted(settings, parted_params):
         variable = VAR.VariableParted(key, parted_params[key])
         settings[key] = variable
 
+def _parse_variable_structure(key, param, args):
+    dict_list = []
+    for values_set in param:
+        struc_dict = {}
+        for j, subparam in enumerate(values_set):
+            var, subkey = _create_variable(subparam)
+            stuc_dict[subkey] = var
+        dict_list.append(struc_dict)
+    variable = VAR.VariableStructure(key, dict_list)
+    return variable
+
 def _parse_variable_list(key, param):
     values_list = []
     for i, p_value in enumerate(param):
@@ -37,6 +48,8 @@ def _create_variable(param, tmp_key = ""):
         var = VAR.VariableReference(key, value)
     elif p_type == "list":
         var = _parse_variable_list(key, param)
+    elif p_type == "structure" or p_type == "struc":
+        var = _parse_variable_list(key, param, args)
     else:
         var = VAR.Variable(key, value)
     return var, key


### PR DESCRIPTION
Introducing following changes:
a) class VariableStructure  
b) TASK_FOR updates and dependencies modyficantions

Changes are not finished due to the fact that:
I'm not fully satisfied with current solution for TASK_FOR (specially modyfication on VariableList). TASK_FOR on initialization gets a variable representing variables list (which is pure VariableList or its reference).

All our variables return simple variable with get_variable function as following examples:
```
VariableParted(<key>, <dictionary of parts>).get_variable(env) -> Variable(<key>, <merged_value>)
VariableReference(<key>, <ref_value>).get_variable(env) -> Variable(<key>, <value>)
VariableList(<key>, <list_of_variables).get_variable(env) -> Variable(<key>, <list_of_values>)
```
[But ofc VariablePath returns VariablePath]

This solution do not allows me to iterate on raw list of variables. By now I wrote simple function get_raw_value for VariableList which gives back its self.value. I guess that VariableList.get_variable( ) should rather return [x.get_variable(env) for x in self.value), however I would like to discuss problem first to find the finest solution. 

Cheers.